### PR TITLE
fix: replace cloudflare ipfs gateway with ipfs.io

### DIFF
--- a/packages/frontend/src/services/NonFungibleTokens.js
+++ b/packages/frontend/src/services/NonFungibleTokens.js
@@ -129,7 +129,7 @@ export default class NonFungibleTokens {
             return `${base_uri}/${media}`;
         }
 
-        return `https://cloudflare-ipfs.com/ipfs/${media}`;
+        return `https://ipfs.io/ipfs/${media}`;
     };
 
     static mapTokenMediaUrl = ({ metadata, ...token }, base_uri) => {


### PR DESCRIPTION
## Issues

The Cloudflare IPFS gateway https://cloudflare-ipfs.com has been turned down, which causes some NFTs in My Near Wallet cannot be displayed correctly. 

Let's switch to https://ipfs.io or https://dweb.link.

Links:
- https://www.reddit.com/r/ipfs/comments/1cuw1r4/cloudflares_ipfs_gateway_will_be_turned_down_in
- https://blog.cloudflare.com/cloudflares-public-ipfs-gateways-and-supporting-interplanetary-shipyard

## Changes description

Replace https://cloudflare-ipfs.com with https://ipfs.io
